### PR TITLE
Add on_thread_exit hook

### DIFF
--- a/lib/puma/dsl.rb
+++ b/lib/puma/dsl.rb
@@ -641,6 +641,23 @@ module Puma
       @options[:before_refork] << block
     end
 
+    # Code to run immediately before a thread exits. The worker does not
+    # accept new requests until this code finishes.
+    #
+    # This hook is useful for cleaning up thread local resources when a thread
+    # is trimmed.
+    #
+    # This can be called multiple times to add several hooks.
+    #
+    # @example
+    #   on_thread_exit do
+    #     puts 'On thread exit...'
+    #   end
+    def on_thread_exit(&block)
+      @options[:before_thread_exit] ||= []
+      @options[:before_thread_exit] << block
+    end
+
     # Code to run out-of-band when the worker is idle.
     # These hooks run immediately after a request has finished
     # processing and there are no busy threads on the worker.

--- a/lib/puma/server.rb
+++ b/lib/puma/server.rb
@@ -241,6 +241,7 @@ module Puma
 
       @thread_pool.out_of_band_hook = @options[:out_of_band]
       @thread_pool.clean_thread_locals = @options[:clean_thread_locals]
+      @thread_pool.before_thread_exit_hook = @options[:before_thread_exit]
 
       if @queue_requests
         @reactor = Reactor.new(@io_selector_backend, &method(:reactor_wakeup))

--- a/test/test_config.rb
+++ b/test/test_config.rb
@@ -430,6 +430,10 @@ class TestConfigFile < TestConfigFileBase
     assert_run_hooks :before_fork
   end
 
+  def test_run_hooks_before_thread_exit
+    assert_run_hooks :before_thread_exit, configured_with: :on_thread_exit
+  end
+
   def test_run_hooks_and_exception
     conf = Puma::Configuration.new do |c|
       c.on_restart do |a|

--- a/test/test_thread_pool.rb
+++ b/test/test_thread_pool.rb
@@ -159,6 +159,24 @@ class TestThreadPool < Minitest::Test
     assert_equal 0, pool.trim_requested
   end
 
+  def test_trim_thread_exit_hook
+    pool = mutex_pool(0, 1)
+    exited = Queue.new
+    pool.before_thread_exit_hook = [
+      proc do
+        exited << 1
+      end
+    ]
+
+    pool << 1
+
+    assert_equal 1, pool.spawned
+
+    pool.trim
+    assert_equal 0, pool.spawned
+    assert_equal 1, exited.length
+  end
+
   def test_autotrim
     pool = mutex_pool(1, 2)
 


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/183131066

For apps that need to tidy up thread-local resources when a thread exits, add a new `on_thread_exit` hook.
This will be called when a thread is being trimmed, just before the thread exits.

An example config entry involving rabbitmq channels being held in thread local variables (one channel per thread):

```ruby
on_thread_exit do
  unless Thread.current[MY_KEY].nil?
    Thread.current[MY_KEY].disconnect
    Thread.current[MY_KEY] = nil
  end
end
```

The hook should be configured with a quick non-blocking operation as it will block new requests from being started in other threads. I wondered about moving the call to the hook outside of the mutex section, but that becomes quite a bit less readable and I can't see what anyone would need to do that would be a blocking operation.